### PR TITLE
Add check to see if the output streams have successfully opened

### DIFF
--- a/source/state_merger.cpp
+++ b/source/state_merger.cpp
@@ -1030,6 +1030,9 @@ void state_merger::print_dot(const string& file_name)
 {
     todot();
     ofstream output1(file_name.c_str());
+    if (output1.fail()) {
+        throw std::ofstream::failure("Unable to open file for writing: " + file_name);
+    }
     output1 << dot_output;
     output1.close();
 }
@@ -1038,6 +1041,9 @@ void state_merger::print_json(const string& file_name)
 {
     tojson();
     ofstream output1(file_name.c_str());
+    if (output1.fail()) {
+        throw std::ofstream::failure("Unable to open file for writing: " + file_name);
+    }
     output1 << json_output;
     output1.close();
 }


### PR DESCRIPTION
Currently, flexfringe silently fails to write output files if for example it does not have permissions to write files in the output directory.

This adds a check for this case so instead of failing silently an exception will be thrown.