### PR TITLE
Add platform specific compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,11 @@ endif()
 
 option(COMPILE_DOCS "This is settable from the command line" OFF)
 
-set(CMAKE_CXX_FLAGS "-Wall")
-set(CMAKE_CXX_FLAGS_DEBUG "-g")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+if (MSVC)
+    add_compile_options("/W4" "$<$<CONFIG:RELEASE>:/O2>")
+else()
+    add_compile_options("-Wall" "-Wextra" "-Werror" "$<$<CONFIG:RELEASE>:-O3>")
+endif()
 
 add_compile_definitions(LOGURU_WITH_STREAMS=1)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,9 @@ option(COMPILE_DOCS "This is settable from the command line" OFF)
 if (MSVC)
     add_compile_options("/W4" "$<$<CONFIG:RELEASE>:/O2>")
 else()
-    add_compile_options("-Wall" "-Wextra" "-Werror" "$<$<CONFIG:RELEASE>:-O3>")
+    add_compile_options("-Wall" "-Wextra"
+                        "$<$<CONFIG:RELEASE>:-O3>"
+                        "$<$<CONFIG:DEBUG>:-g>")
 endif()
 
 add_compile_definitions(LOGURU_WITH_STREAMS=1)


### PR DESCRIPTION
The main CMakeLists.txt sets some compiler flags but currently these are not compatible with msvc, which uses different flags. This PR fixes that, and adds a way to set the right flags depending on what compiler is used.

