### PR TITLE
Fixed Splitting Memory Leaks

### DIFF
--- a/source/apta.cpp
+++ b/source/apta.cpp
@@ -311,6 +311,7 @@ apta_guard::apta_guard(){
     undo_split = nullptr;
     target = nullptr;
     data = nullptr;
+
     try {
         data = (DerivedGuardDataRegister<evaluation_guard_data>::getMap())->at("count_guard_data")();
         data->guard = this;
@@ -324,8 +325,11 @@ apta_guard::apta_guard(apta_guard* g){
     target = nullptr;
     data = nullptr;
 
-    min_attribute_values = bound_map(g->min_attribute_values);
-    max_attribute_values = bound_map(g->max_attribute_values);
+    if (g!= nullptr)
+    {
+        min_attribute_values = bound_map(g->min_attribute_values);
+        max_attribute_values = bound_map(g->max_attribute_values);
+    }
 
     try {
         data = (DerivedGuardDataRegister<evaluation_guard_data>::getMap())->at("count_guard_data")();
@@ -343,8 +347,11 @@ void apta_guard::initialize(apta_guard* g){
     min_attribute_values.clear();
     max_attribute_values.clear();
 
-    min_attribute_values.insert(g->min_attribute_values.begin(), g->min_attribute_values.end());
-    max_attribute_values.insert(g->max_attribute_values.begin(), g->max_attribute_values.end());
+    if (g!= nullptr)
+    {
+        min_attribute_values.insert(g->min_attribute_values.begin(), g->min_attribute_values.end());
+        max_attribute_values.insert(g->max_attribute_values.begin(), g->max_attribute_values.end());
+    }
 }
 
 void apta_node::add_tail(tail* t){
@@ -355,9 +362,9 @@ void apta_node::add_tail(tail* t){
 
     if(access_trace == nullptr){
         if(t->past() != nullptr)
-            access_trace = inputdata_locator::get()->access_trace(t->past());
+            set_access_trace(inputdata_locator::get()->access_trace(t->past()));
         else
-            access_trace = mem_store::create_trace();
+            set_access_trace(mem_store::create_trace());
     }
 }
 
@@ -408,6 +415,14 @@ void apta_node::initialize(apta_node* n){
     guards.clear();
     if(performed_splits != nullptr) performed_splits->clear();
 }
+
+void apta_node::erase_guards() {
+    for (auto& guard: guards) {
+        mem_store::delete_guard(guard.second);
+    }
+    guards.clear();
+}
+
 
 apta_node* apta_node::child(tail* t){
         int symbol = t->get_symbol();
@@ -472,23 +487,32 @@ apta_guard* apta_node::guard(tail* t){
     return nullptr;
 }
 
-void apta_node::set_child(tail* t, apta_node* node){
-    int symbol = t->get_symbol();
-    auto it = guards.lower_bound(symbol);
+void apta_node::set_child(int i, apta_node* node) {
+    if (const auto it = guards.find(i); it != guards.end()) {
+        if (node != nullptr) it->second->target = node;
+        else guards.erase(it);
+    } else {
+        auto* g = mem_store::create_guard(nullptr);
+        guards.insert(std::pair(i, g));
+        g->target = node;
+    }
+};
+
+void apta_node::set_child(tail* t, apta_node* node) {
+    int  symbol = t->get_symbol();
+    auto it     = guards.lower_bound(symbol);
     auto it_end = guards.upper_bound(symbol);
-    for(;it != it_end; ++it){
-        if(it->second->bounds_satisfy(t)){
+    for (; it != it_end; ++it) {
+        if (it->second->bounds_satisfy(t)) {
             break;
         }
     }
-    if(it != guards.end()){
-        if(node != 0)
-            it->second->target = node;
-        else
-            guards.erase(it);
+    if (it != guards.end()) {
+        if (node != 0) it->second->target = node;
+        else guards.erase(it);
     } else {
-        apta_guard* g = new apta_guard();
-        guards.insert(std::pair<int,apta_guard*>(t->get_symbol(),g));
+        apta_guard* g = mem_store::create_guard(nullptr);
+        guards.insert(std::pair<int, apta_guard*>(t->get_symbol(), g));
         g->target = node;
     }
 };
@@ -639,7 +663,7 @@ void tail_iterator::next_node(){
 void tail_iterator::increment() {
     current_tail = current_tail->next_in_list;
     while(current_tail != nullptr && current_tail->split_to != nullptr) current_tail = current_tail->next_in_list;
-    
+
     while(current_tail == nullptr){
         if(current == nullptr) return;
         next_node();

--- a/source/apta.h
+++ b/source/apta.h
@@ -266,6 +266,14 @@ class apta_node{
 
 public:
     trace* get_access_trace(){ return access_trace; }
+
+    void set_access_trace(trace* t) {
+        if(access_trace != nullptr) access_trace->erase();
+        access_trace = t;
+    }
+
+    void erase_guards();
+
     apta_node* get_source(){ return source; }
     apta_node* get_merged_head(){ return representative_of; }
     apta_node* get_next_merged(){ return next_merged_node; }
@@ -351,18 +359,7 @@ public:
     guard_map::iterator guards_start(){ return guards.begin(); }
     guard_map::iterator guards_end(){ return guards.end(); }
 
-    void set_child(int i, apta_node* node){
-        if(const auto it = guards.find(i); it != guards.end()){
-            if(node != nullptr)
-                it->second->target = node;
-            else
-                guards.erase(it);
-        } else {
-            auto* g = new apta_guard();
-            guards.insert(std::pair(i,g));
-            g->target = node;
-        }
-    };
+    void set_child(int i, apta_node* node);
 
     apta_node* get_child(int c){
         apta_node* rep = find();

--- a/source/input/tail.cpp
+++ b/source/input/tail.cpp
@@ -82,11 +82,12 @@ tail::tail(tail* ot){
 }
 
 void tail::initialize(tail* ot){
-    if(ot != nullptr){
+    if (ot != nullptr) {
         td = ot->td;
         tr = ot->tr;
     } else {
-        td = std::make_shared<tail_data>();
+        if (td != nullptr && td.use_count() == 1) td->initialize();
+        else td = std::make_shared<tail_data>();
         tr = nullptr;
     }
     past_tail = nullptr;
@@ -193,11 +194,12 @@ tail_data::tail_data() {
 tail_data::~tail_data() = default;
 
 void tail_data::initialize() {
-    auto inputdata = inputdata_locator::get();
     index = -1;
     symbol = -1;
-    attr = std::make_unique<double[]>(inputdata->get_num_symbol_attributes());
-    for(int i = 0; i < inputdata->get_num_symbol_attributes(); ++i){
+    // reuse existing array instead of reallocating
+    auto inputdata = inputdata_locator::get();
+    int n = inputdata->get_num_symbol_attributes();
+    for(int i = 0; i < n; ++i){
         attr[i] = 0.0;
     }
     data = "";

--- a/source/mem_store.cpp
+++ b/source/mem_store.cpp
@@ -13,12 +13,13 @@ std::list< extend_refinement* > mem_store::extendref_store;
 
 void mem_store::delete_node(apta_node* node){
     assert(node != nullptr);
+    node->set_access_trace(nullptr);
+    node->erase_guards();
     node_store.push_front(node);
-    //cerr << "delete " << node << endl;
-    //delete node;
 };
+
 apta_node* mem_store::create_node(apta_node* other_node){
-    apta_node* node = 0;
+    apta_node* node = nullptr;
     if(!node_store.empty()){
         node = node_store.front();
         node_store.pop_front();
@@ -33,7 +34,7 @@ void mem_store::delete_guard(apta_guard* guard){
     guard_store.push_front(guard);
 };
 apta_guard* mem_store::create_guard(apta_guard* other_guard){
-    apta_guard* guard = 0;
+    apta_guard* guard = nullptr;
     if(!guard_store.empty()){
         guard = guard_store.front();
         guard_store.pop_front();
@@ -41,43 +42,6 @@ apta_guard* mem_store::create_guard(apta_guard* other_guard){
     } else { guard = new apta_guard(other_guard); }
     return guard;
 };
-//
-//void mem_store::delete_tail(tail* t){
-//    assert(t != nullptr);
-//    tail_store.push_front(t);
-//};
-//tail* mem_store::create_tail(tail* other_tail){
-//    tail* t = 0;
-//    if(!tail_store.empty()){
-//        tail* t2 = tail_store.front();
-//        if(t2->next_in_list == 0) { tail_store.pop_front(); t = t2; }
-//        else { t = t2->next_in_list; t2->next_in_list = t->next_in_list; }
-//        t->initialize(other_tail);
-//    } else { t = new tail(other_tail); }
-//    return t;
-//};
-
-//void mem_store::delete_trace(trace* tr){
-//    assert(tr != nullptr);
-//    tail* t = tr->head;
-//    while(t != 0){
-//        mem_store::delete_tail(t);
-//        tail* t2 = t;
-//        t = t2->future();
-//    }
-//    trace_store.push_front(tr);
-//};
-//trace* mem_store::create_trace(){
-//    trace* t;
-//    if(!trace_store.empty()){
-//        t = trace_store.front();
-//        trace_store.pop_front();
-//        t->initialize();
-//    } else {
-//        t = new trace();
-//    }
-//    return t;
-//};
 
 void mem_store::delete_merge_refinement(merge_refinement* ref){
     assert(ref != nullptr);
@@ -178,6 +142,9 @@ trace *mem_store::create_trace(inputdata* inputData) {
 
 void mem_store::delete_tail(tail * t) {
     assert(t != nullptr);
+    for (tail *t2 = t; t2 != nullptr; t2 = t2->next_in_list) {
+        if (t2->td != nullptr && t2->td.use_count() > 1) t2->td = nullptr;
+    }
     tail_store.push_front(t);
 }
 

--- a/source/mem_store.h
+++ b/source/mem_store.h
@@ -4,7 +4,6 @@
 #include <list>
 #include "refinement.h"
 #include "apta.h"
-#include "state_merger.h"
 
 #include "input/inputdata.h"
 #include "input/trace.h"
@@ -17,8 +16,6 @@ private:
 public:
     static std::list< apta_node* > node_store;
     static std::list< apta_guard* > guard_store;
-//    static std::list< tail* > tail_store;
-//    static std::list< trace* > trace_store;
     static std::list< merge_refinement* > mergeref_store;
     static std::list< split_refinement* > splitref_store;
     static std::list< extend_refinement* > extendref_store;
@@ -28,9 +25,6 @@ public:
 
     static void delete_guard(apta_guard*);
     static apta_guard* create_guard(apta_guard* other_guard);
-
-//    static void delete_tail(tail*);
-//    static tail* create_tail(tail* other_tail);
 
     static void delete_merge_refinement(merge_refinement*);
     static merge_refinement* create_merge_refinement(state_merger* m, double s, apta_node* l, apta_node* r);
@@ -43,13 +37,11 @@ public:
 
     static void erase();
 
-//    static void delete_trace(trace*);
-//    static trace* create_trace();
-
     static void delete_trace(trace*);
     static trace* create_trace(inputdata* = nullptr);
 
-    static void delete_tail(tail*);
+    static void delete_tail(tail* t);
+
     static tail* create_tail(tail* other_tail);
 };
 

--- a/source/refinement.cpp
+++ b/source/refinement.cpp
@@ -196,7 +196,11 @@ inline bool merge_refinement::testref(state_merger* m){
 
 inline void merge_refinement::erase(){
     refs -= 1;
-    if(refs == 0) mem_store::delete_merge_refinement(this);
+    if(refs == 0) {
+        red_trace->erase();
+        blue_trace->erase();
+        mem_store::delete_merge_refinement(this);
+    }
 };
 
 inline void split_refinement::print() const{
@@ -256,9 +260,11 @@ inline bool split_refinement::testref(state_merger* m){
 
 inline void split_refinement::erase(){
     refs -= 1;
-    if(refs == 0) mem_store::delete_split_refinement(this);
+    if(refs == 0) {
+        red_trace->erase();
+        mem_store::delete_split_refinement(this);
+    }
 };
-
 inline void extend_refinement::print() const{
     if(STORE_ACCESS_STRINGS)
         cout << "extend( " << score << " " << red_trace->to_string() << " )" << endl;
@@ -306,9 +312,11 @@ inline bool extend_refinement::testref(state_merger* m){
 
 inline void extend_refinement::erase(){
     refs -= 1;
-    if(refs == 0) mem_store::delete_extend_refinement(this);
+    if(refs == 0) {
+        red_trace->erase();
+        mem_store::delete_extend_refinement(this);
+    }
 };
-
 void refinement::print_refinement_list_json(iostream& output, refinement_list* list){
     output << "[\n";
 

--- a/source/state_merger.cpp
+++ b/source/state_merger.cpp
@@ -48,8 +48,8 @@ apta_node* state_merger::get_state_from_trace(trace* t) const{
  * @param n 
  * @return tail* 
  */
-trace* state_merger::get_trace_from_state(apta_node* n){
-    return n->access_trace;
+trace *state_merger::get_trace_from_state(apta_node *n) {
+    return n->get_access_trace();
 }
 
 /* --------------------------------- Special state sets, used by red blue framework -----------------------------*/
@@ -428,8 +428,8 @@ bool state_merger::split(apta_node* new_node, apta_node* old_node, int depth, bo
 
     tail_iterator it = tail_iterator(old_node);
     tail* t = *it;
-    new_node->access_trace = inputdata_locator::get()->access_trace(new_node->tails_head->past());
-    if(t != nullptr) old_node->access_trace = inputdata_locator::get()->access_trace(t->past());
+    new_node->set_access_trace(inputdata_locator::get()->access_trace(new_node->tails_head->past()));
+    if (t != nullptr) old_node->set_access_trace(inputdata_locator::get()->access_trace(t->past()));
 
     if(test) {
         // test early stopping conditions


### PR DESCRIPTION
Fixed the memory leaks within the splitting process
- Guards are now properly allocated and deallocated through the memory store instead of using bare new/delete
- Trace reuse is improved by introducing a dedicated setter that properly cleans up the old trace before reassigning
- Tail data is now reused